### PR TITLE
Add option scoring column

### DIFF
--- a/nextjs/app/ProductTable.tsx
+++ b/nextjs/app/ProductTable.tsx
@@ -3,15 +3,19 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { extendedProducts } from "./hooks/sg";
 import { ExtendedProduct } from "./hooks/types";
+import { addScoreColumn } from "@/lib/scorer";
 import { ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import BarrierVisualization from "./components/BarrierVisualization";
 import ProductInfoPanel from "./components/ProductInfoPanel";
 import PriceHistoryChart from "./components/PriceHistoryChart";
 
-type SortKey = keyof ExtendedProduct;
+type SortKey = keyof ExtendedProduct | "score";
+
+type ScoredProduct = ExtendedProduct & { score: number };
 
 const columns: SortKey[] = [
+  "score",
   "Isin",
   "AssetName",
   "diffToLower",
@@ -58,8 +62,10 @@ export default function ProductTable({ limit = 10, offset = 0, calcDateFrom, cal
     getProducts();
   }, [limit, offset, calcDateFrom, calcDateTo, assetId]);
 
-  const sortedProducts = useMemo(() => {
-    let sortableProducts = [...products];
+  const scoredProducts: ScoredProduct[] = useMemo(() => addScoreColumn(products), [products]);
+
+  const sortedProducts: ScoredProduct[] = useMemo(() => {
+    let sortableProducts = [...scoredProducts];
     if (sortConfig !== null) {
       sortableProducts.sort((a, b) => {
         // @ts-ignore
@@ -74,7 +80,7 @@ export default function ProductTable({ limit = 10, offset = 0, calcDateFrom, cal
       });
     }
     return sortableProducts;
-  }, [products, sortConfig]);
+  }, [scoredProducts, sortConfig]);
 
   const requestSort = (key: SortKey) => {
     let direction: "ascending" | "descending" = "ascending";
@@ -150,7 +156,9 @@ const getSortIndicator = (key: SortKey) => {
                     key={column}
                     className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
                   >
-                    {product[column] as string}
+                    {column === 'score'
+                      ? product.score.toFixed(3)
+                      : (product[column] as string)}
                   </td>
                 ))}
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-600">

--- a/nextjs/lib/scorer.ts
+++ b/nextjs/lib/scorer.ts
@@ -1,0 +1,53 @@
+export interface ScoreWeights {
+  wR: number;
+  wD: number;
+  wB: number;
+  wV: number;
+  wT: number;
+}
+
+export function addScoreColumn<T extends { potentialReturn: number; Offer: number; bollingerWidth: string | number; var95: string | number; diffToLower: string | number; diffToUpper: string | number; daysUntilExpiry: number; }>(
+  rows: T[],
+  weights: ScoreWeights = { wR: 0.25, wD: 0.2, wB: 0.15, wV: 0.15, wT: 0.25 }
+): (T & { score: number })[] {
+  if (!rows.length) return [];
+
+  const getD = (r: T) => Math.min(Number(r.diffToLower), Number(r.diffToUpper));
+
+  const mins = {
+    R: Math.min(...rows.map(r => r.potentialReturn)),
+    B: Math.min(...rows.map(r => Number(r.bollingerWidth))),
+    V: Math.min(...rows.map(r => Number(r.var95))),
+    D: Math.min(...rows.map(getD)),
+    T: Math.min(...rows.map(r => r.daysUntilExpiry)),
+  };
+  const maxs = {
+    R: Math.max(...rows.map(r => r.potentialReturn)),
+    B: Math.max(...rows.map(r => Number(r.bollingerWidth))),
+    V: Math.max(...rows.map(r => Number(r.var95))),
+    D: Math.max(...rows.map(getD)),
+    T: Math.max(...rows.map(r => r.daysUntilExpiry)),
+    P: Math.max(...rows.map(r => r.Offer)),
+  };
+
+  const mm = (x: number, min: number, max: number) => (max === min ? 0.5 : (x - min) / (max - min));
+
+  return rows.map(r => {
+    const Rp = mm(r.potentialReturn, mins.R, maxs.R);
+    const Bp = mm(Number(r.bollingerWidth), mins.B, maxs.B);
+    const Vp = mm(Number(r.var95), mins.V, maxs.V);
+    const Dval = getD(r);
+    const Dp = mm(Dval, mins.D, maxs.D);
+    const Tp = mm(r.daysUntilExpiry, mins.T, maxs.T);
+
+    const Pfactor = 1 - r.Offer / maxs.P;
+
+    const s = weights.wR * Rp * Pfactor +
+              weights.wD * Dp +
+              weights.wB * (1 - Bp) +
+              weights.wV * (1 - Vp) +
+              weights.wT * Tp;
+
+    return { ...r, score: s };
+  });
+}


### PR DESCRIPTION
## Summary
- implement a scoring utility to rank products using weighted factors
- compute scores in `ProductTable` and display the new column

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688770186b4c83288f29789093a7053f